### PR TITLE
Add /v2 to golang module path

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,7 @@ ext {
                  title: project.name.tokenize("-").collect{it.capitalize()}.join(" "),
                  snake: project.name.replaceAll("-", "_")],
           version: [_: vers.tfs,
+                    major: vers.tfs.tokenize('.').first(),
                     grpc: [_: vers.grpc,
                            dotnet: vers.grpc.tokenize(".").withIndex().collect{ v, i ->
                                      i == 0 ? ((v as int) + 1) : v

--- a/gradle/golang.gradle
+++ b/gradle/golang.gradle
@@ -157,7 +157,7 @@ task __golang__ {
       into src
       filter { line ->
          line.replaceFirst('(\\w+\\s+")(tensorflow(_serving)?(/\\w+)*")',
-                           '$1' + git + '/' + src + '/$2')
+                           '$1' + "${git}/v${dist.version.major}/${src}/" + '$2')
       }
     }
     copy {

--- a/mod.go
+++ b/mod.go
@@ -1,4 +1,4 @@
-module github.com/figroc/tensorflow-serving-client
+module github.com/figroc/tensorflow-serving-client/v${TFSCLIENT_VERSION_MAJOR}
 
 go 1.12
 


### PR DESCRIPTION
Golang modules now require major versions >= 2 to contain the version in the path. Closes #7 